### PR TITLE
1) When maintainer commands initialize, they set the current position…

### DIFF
--- a/Competition2018/src/main/java/competition/subsystems/elevator/ElevatorSubsystem.java
+++ b/Competition2018/src/main/java/competition/subsystems/elevator/ElevatorSubsystem.java
@@ -226,6 +226,8 @@ public class ElevatorSubsystem extends BaseSetpointSubsystem implements Periodic
         motor.configForwardSoftLimitThreshold(upperLimit, 0);
 
         setSoftLimitsEnabled(true);
+        
+        setTargetHeight(getCurrentHeightInInches());
     }
 
     public void uncalibrate() {

--- a/Competition2018/src/main/java/competition/subsystems/elevator/commands/ElevatorMaintainerCommand.java
+++ b/Competition2018/src/main/java/competition/subsystems/elevator/commands/ElevatorMaintainerCommand.java
@@ -42,6 +42,9 @@ public class ElevatorMaintainerCommand extends BaseCommand {
             log.warn("ELEVATOR UNCALIBRATED - THIS COMMAND WILL NOT DO ANYTHING!");
             giveUpCalibratingTime = Timer.getFPGATimestamp() + elevatorCalibrationAttemptTimeMS.get();
             log.info("Attempting calibration from " + Timer.getFPGATimestamp() + " until " + giveUpCalibratingTime);
+        } else {
+            log.info("Setting current height as target height");
+            elevator.setTargetHeight(elevator.getCurrentHeightInInches());
         }
     }
 

--- a/Competition2018/src/main/java/competition/subsystems/wrist/WristSubsystem.java
+++ b/Competition2018/src/main/java/competition/subsystems/wrist/WristSubsystem.java
@@ -121,6 +121,8 @@ public class WristSubsystem extends BaseSetpointSubsystem implements PeriodicDat
 
         log.info("Lower limit set at: " + lowerLimit);
         motor.configReverseSoftLimitThreshold(lowerLimit, 0);
+        
+        setTargetAngle(getTargetAngle());
     }
 
     public double getWristAngle() {

--- a/Competition2018/src/main/java/competition/subsystems/wrist/commands/WristMaintainerCommand.java
+++ b/Competition2018/src/main/java/competition/subsystems/wrist/commands/WristMaintainerCommand.java
@@ -27,6 +27,11 @@ public class WristMaintainerCommand extends BaseCommand {
     @Override
     public void initialize() {
         log.info("Initializing");
+        
+        if (wrist.getIsCalibrated()) {
+            log.info("Setting current angle as desired angle");
+            wrist.setTargetAngle(wrist.getWristAngle());
+        }
     }
 
     @Override

--- a/Competition2018/src/test/java/competition/subsystems/elevator/commands/ElevatorMaintainerCommandTest.java
+++ b/Competition2018/src/test/java/competition/subsystems/elevator/commands/ElevatorMaintainerCommandTest.java
@@ -36,9 +36,9 @@ public class ElevatorMaintainerCommandTest extends BaseCompetitionTest {
     @Test
     public void checkGoUp() {
         ((MockCANTalon)elevator.motor).setPosition(3700);
-        elevator.setTargetHeight(70);
         elevator.isCalibrated();
         command.initialize();
+        elevator.setTargetHeight(70);
         command.execute();
         assertTrue(elevator.motor.getMotorOutputPercent() > 0);
     }
@@ -46,8 +46,8 @@ public class ElevatorMaintainerCommandTest extends BaseCompetitionTest {
     @Test
     public void checkGoDown() {
         ((MockCANTalon)elevator.motor).setPosition(3700);
-        elevator.setTargetHeight(12);
         command.initialize();
+        elevator.setTargetHeight(12);
         command.execute();
         assertTrue(elevator.motor.getMotorOutputPercent() < 0);
     }
@@ -75,8 +75,8 @@ public class ElevatorMaintainerCommandTest extends BaseCompetitionTest {
     public void checkMaintainerMode() {
         elevator.calibrateHere();
         ((MockCANTalon)elevator.motor).setPosition(3700);
-        elevator.setTargetHeight(70);
         command.initialize();
+        elevator.setTargetHeight(70);
         command.execute();
         assertEquals(1, elevator.motor.getMotorOutputPercent(), .01);
     }
@@ -102,6 +102,7 @@ public class ElevatorMaintainerCommandTest extends BaseCompetitionTest {
         command.execute();
         assertEquals(-.2, elevator.motor.getMotorOutputPercent(), .01);
         elevator.calibrateHere();
+        elevator.setTargetHeight(70);
         command.execute();
         assertEquals(1, elevator.motor.getMotorOutputPercent(), .01);
         elevator.uncalibrate();
@@ -122,6 +123,7 @@ public class ElevatorMaintainerCommandTest extends BaseCompetitionTest {
         command.execute();
         assertEquals(.15, elevator.motor.getMotorOutputPercent(), .01);
         elevator.calibrateHere();
+        elevator.setTargetHeight(70);
         command.execute();
         assertEquals(1, elevator.motor.getMotorOutputPercent(), .01);
         elevator.uncalibrate();
@@ -134,9 +136,9 @@ public class ElevatorMaintainerCommandTest extends BaseCompetitionTest {
     public void checkMotionMagicModeGoUp() {
         command.isMotionMagicMode(true);
         ((MockCANTalon)elevator.motor).setPosition(3700);
-        elevator.setTargetHeight(70);
         elevator.isCalibrated();
         command.initialize();
+        elevator.setTargetHeight(70);
         command.execute();
         assertEquals(6700, ((MockCANTalon)elevator.motor).getSetpoint(), 0.001);
     }
@@ -145,8 +147,8 @@ public class ElevatorMaintainerCommandTest extends BaseCompetitionTest {
     public void checkMotionMagicModeGoDown() {
         command.isMotionMagicMode(true);
         ((MockCANTalon)elevator.motor).setPosition(3700);
-        elevator.setTargetHeight(12);
         command.initialize();
+        elevator.setTargetHeight(12);
         command.execute();
         assertEquals(900, ((MockCANTalon)elevator.motor).getSetpoint(), 0.001);
     }
@@ -166,8 +168,8 @@ public class ElevatorMaintainerCommandTest extends BaseCompetitionTest {
         command.isMotionMagicMode(true);
         elevator.calibrateHere();
         ((MockCANTalon)elevator.motor).setPosition(3700);
-        elevator.setTargetHeight(70);
         command.initialize();
+        elevator.setTargetHeight(70);
         command.execute();
         assertEquals(6700, ((MockCANTalon)elevator.motor).getSetpoint(), 0.001);
     }
@@ -182,6 +184,7 @@ public class ElevatorMaintainerCommandTest extends BaseCompetitionTest {
         command.execute();
         assertEquals(-.2, elevator.motor.getMotorOutputPercent(), .01);
         elevator.calibrateHere();
+        elevator.setTargetHeight(70);
         command.execute();
         assertEquals(10400, ((MockCANTalon)elevator.motor).getSetpoint(), 0.001);
         elevator.uncalibrate();
@@ -203,6 +206,7 @@ public class ElevatorMaintainerCommandTest extends BaseCompetitionTest {
         command.execute();
         assertEquals(.15, elevator.motor.getMotorOutputPercent(), .01);
         elevator.calibrateHere();
+        elevator.setTargetHeight(70);
         command.execute();
         assertEquals(10400, ((MockCANTalon)elevator.motor).getSetpoint(), 0.001);
         elevator.uncalibrate();

--- a/Competition2018/src/test/java/competition/subsystems/wrist/commands/WristMaintainerCommandTest.java
+++ b/Competition2018/src/test/java/competition/subsystems/wrist/commands/WristMaintainerCommandTest.java
@@ -28,10 +28,9 @@ public class WristMaintainerCommandTest extends BaseCompetitionTest {
     
     @Test
     public void testMaintain() {
-        wrist.setTargetAngle(45);
         wrist.calibrateHere();
-        
         command.initialize();
+        wrist.setTargetAngle(45);
         command.execute();
         
         assertEquals(-wrist.getMaximumAllowedPower(), wrist.motor.getMotorOutputPercent(), 0.001);


### PR DESCRIPTION
… as the target position

2) When subsystems calibrate, they set the current position as the target position

We will have to ensure that autonomous commands that attempt to set target heights/angles continually set the target height, otherwise the robot's attempts to calibrate may interfere.