### PR TITLE
Register power state manager as periodic data source

### DIFF
--- a/Competition2018/src/main/java/competition/Robot.java
+++ b/Competition2018/src/main/java/competition/Robot.java
@@ -11,6 +11,7 @@ import competition.subsystems.drive.DriveSubsystem;
 import competition.subsystems.elevator.ElevatorSubsystem;
 import competition.subsystems.offboard.OffboardInterfaceSubsystem;
 import competition.subsystems.pose.PoseSubsystem;
+import competition.subsystems.power_state_manager.PowerStateManagerSubsystem;
 import competition.subsystems.wrist.WristSubsystem;
 import xbot.common.command.BaseRobot;
 
@@ -41,6 +42,7 @@ public class Robot extends BaseRobot {
 
         registerPeriodicDataSource(this.injector.getInstance(PoseSubsystem.class));
         registerPeriodicDataSource(this.injector.getInstance(OffboardInterfaceSubsystem.class));
+        registerPeriodicDataSource(this.injector.getInstance(PowerStateManagerSubsystem.class));
         
         registerPeriodicDataSource(this.injector.getInstance(DriveSubsystem.class));
         if (contract.elevatorReady()) {


### PR DESCRIPTION
This was missed in the original PR. Only necessary for updating from the SD property.