### PR TITLE
Rumble when no cube

### DIFF
--- a/Competition2018/src/main/java/competition/Robot.java
+++ b/Competition2018/src/main/java/competition/Robot.java
@@ -6,6 +6,7 @@ import java.io.File;
 import org.apache.log4j.Logger;
 
 import competition.operator_interface.OperatorCommandMap;
+import competition.operator_interface.RumbleManager;
 import competition.subsystems.SubsystemDefaultCommandMap;
 import competition.subsystems.autonomous.selection.AutonomousCommandSelector;
 import competition.subsystems.drive.DriveSubsystem;
@@ -50,6 +51,7 @@ public class Robot extends BaseRobot {
         registerPeriodicDataSource(this.injector.getInstance(PoseSubsystem.class));
         registerPeriodicDataSource(this.injector.getInstance(OffboardInterfaceSubsystem.class));
         registerPeriodicDataSource(this.injector.getInstance(PowerStateManagerSubsystem.class));
+        registerPeriodicDataSource(this.injector.getInstance(RumbleManager.class));
         
         registerPeriodicDataSource(this.injector.getInstance(DriveSubsystem.class));
         if (contract.elevatorReady()) {

--- a/Competition2018/src/main/java/competition/operator_interface/OperatorCommandMap.java
+++ b/Competition2018/src/main/java/competition/operator_interface/OperatorCommandMap.java
@@ -43,6 +43,8 @@ import competition.subsystems.gripperintake.commands.GripperRotateClockwiseComma
 import competition.subsystems.gripperintake.commands.GripperRotateCounterClockwiseCommand;
 import competition.subsystems.offboard.OffboardInterfaceSubsystem;
 import competition.subsystems.offboard.commands.AcquireVisibleCubeCommand;
+import competition.subsystems.offboard.commands.IdentifyAndPurePursuitToVisibleCubeCommand;
+import competition.subsystems.offboard.commands.IdentifyTargetCubeCommand.TimeoutPreset;
 import competition.subsystems.offboard.commands.NavToTestGoalCommand;
 import competition.subsystems.offboard.commands.PurePursuitToVisibleCubeCommand;
 import competition.subsystems.offboard.data.TargetCubeInfo;
@@ -203,9 +205,7 @@ public class OperatorCommandMap {
                 NavToTestGoalCommand testNav,
                 DriveAtVelocityInfinitelyCommand driveAtVelLow,
                 DriveAtVelocityInfinitelyCommand driveAtVelHigh,
-                PurePursuitToVisibleCubeCommand driveToLocalCubeCommand,
-                OffboardInterfaceSubsystem offboardSubsystem,
-                PoseSubsystem poseSubsystem,
+                IdentifyAndPurePursuitToVisibleCubeCommand driveToLocalCubeCommand,
                 ExtendRetractZedCommand extendZed,
                 ExtendRetractZedCommand retractZed) {
         acquireCube.includeOnSmartDashboard();
@@ -217,6 +217,7 @@ public class OperatorCommandMap {
         driveAtVelHigh.setVelocity(50);
         driveAtVelHigh.includeOnSmartDashboard("Test drive at velocity (high)");
 
+        driveToLocalCubeCommand.setTimeoutPreset(TimeoutPreset.Manual);
         driveToLocalCubeCommand.includeOnSmartDashboard("Drive to local cube");
         oi.driverGamepad.getifAvailable(7).whilePressedNoRestart(driveToLocalCubeCommand);
         oi.driverGamepad.getifAvailable(8).whilePressedNoRestart(driveToLocalCubeCommand);

--- a/Competition2018/src/main/java/competition/operator_interface/RumbleManager.java
+++ b/Competition2018/src/main/java/competition/operator_interface/RumbleManager.java
@@ -1,0 +1,57 @@
+package competition.operator_interface;
+
+import javax.inject.Singleton;
+
+import com.google.inject.Inject;
+
+import edu.wpi.first.wpilibj.GenericHID;
+import edu.wpi.first.wpilibj.GenericHID.RumbleType;
+import edu.wpi.first.wpilibj.Timer;
+import xbot.common.command.PeriodicDataSource;
+import xbot.common.controls.sensors.XJoystick;
+
+@Singleton
+public class RumbleManager implements PeriodicDataSource {
+    private double lastDriverRequestEndTime = -1;
+    private XJoystick driverGamepad;
+    
+    @Inject
+    public RumbleManager(OperatorInterface oi) {
+        this.driverGamepad = oi.driverGamepad;
+    }
+    
+    public void stopDriverGamepadRumble() {
+        writeRumble(driverGamepad, 0);
+        lastDriverRequestEndTime = -1;
+    }
+    
+    public void rumbleDriverGamepad(double intensity, double length) {
+        writeRumble(driverGamepad, intensity);
+        lastDriverRequestEndTime = Timer.getFPGATimestamp() + length;
+    }
+    
+    private void writeRumble(XJoystick gamepad, double intensity) {
+
+        GenericHID internalJoystick = gamepad.getRawWPILibJoystick();
+        
+        if (internalJoystick == null) {
+            return;
+        }
+
+        internalJoystick.setRumble(RumbleType.kLeftRumble, intensity);
+        internalJoystick.setRumble(RumbleType.kRightRumble, intensity);
+    }
+
+    @Override
+    public void updatePeriodicData() {
+        if (lastDriverRequestEndTime > 0 && Timer.getFPGATimestamp() > lastDriverRequestEndTime) {
+            writeRumble(driverGamepad, 0);
+            lastDriverRequestEndTime = -1;
+        }
+    }
+
+    @Override
+    public String getName() {
+        return "RumbleManager";
+    }
+}

--- a/Competition2018/src/main/java/competition/subsystems/offboard/commands/IdentifyAndPurePursuitToVisibleCubeCommand.java
+++ b/Competition2018/src/main/java/competition/subsystems/offboard/commands/IdentifyAndPurePursuitToVisibleCubeCommand.java
@@ -8,11 +8,18 @@ public class IdentifyAndPurePursuitToVisibleCubeCommand extends BaseCommandGroup
     private final IdentifyTargetCubeCommand identifyCommand;
     
     @Inject
-    public IdentifyAndPurePursuitToVisibleCubeCommand(IdentifyTargetCubeCommand identify, PurePursuitToVisibleCubeCommand pursue) {
+    public IdentifyAndPurePursuitToVisibleCubeCommand(
+            StopRumbleCommand stopRumble,
+            IdentifyTargetCubeCommand identify,
+            RumbleIfNoTargetAvailableCommand rumble,
+            PurePursuitToVisibleCubeCommand pursue) {
         this.identifyCommand = identify;
         pursue.setTargetCubeSupplier(() -> identify.getChosenTarget());
         
+        // TODO: Don't rumble in auto
+        this.addSequential(stopRumble);
         this.addSequential(identify);
+        this.addSequential(rumble);
         this.addSequential(pursue);
     }
     

--- a/Competition2018/src/main/java/competition/subsystems/offboard/commands/IdentifyAndPurePursuitToVisibleCubeCommand.java
+++ b/Competition2018/src/main/java/competition/subsystems/offboard/commands/IdentifyAndPurePursuitToVisibleCubeCommand.java
@@ -1,0 +1,22 @@
+package competition.subsystems.offboard.commands;
+
+import com.google.inject.Inject;
+
+import xbot.common.command.BaseCommandGroup;
+
+public class IdentifyAndPurePursuitToVisibleCubeCommand extends BaseCommandGroup {
+    private final IdentifyTargetCubeCommand identifyCommand;
+    
+    @Inject
+    public IdentifyAndPurePursuitToVisibleCubeCommand(IdentifyTargetCubeCommand identify, PurePursuitToVisibleCubeCommand pursue) {
+        this.identifyCommand = identify;
+        pursue.setTargetCubeSupplier(() -> identify.getChosenTarget());
+        
+        this.addSequential(identify);
+        this.addSequential(pursue);
+    }
+    
+    public void setTimeoutPreset(IdentifyTargetCubeCommand.TimeoutPreset timeoutPreset) {
+        identifyCommand.setTimeoutPreset(timeoutPreset);
+    }
+}

--- a/Competition2018/src/main/java/competition/subsystems/offboard/commands/IdentifyTargetCubeCommand.java
+++ b/Competition2018/src/main/java/competition/subsystems/offboard/commands/IdentifyTargetCubeCommand.java
@@ -1,0 +1,58 @@
+package competition.subsystems.offboard.commands;
+
+import com.google.inject.Inject;
+
+import competition.subsystems.offboard.OffboardInterfaceSubsystem;
+import competition.subsystems.offboard.data.TargetCubeInfo;
+import xbot.common.properties.DoubleProperty;
+import xbot.common.properties.XPropertyManager;
+
+public class IdentifyTargetCubeCommand extends xbot.common.command.BaseCommand {
+
+    private final OffboardInterfaceSubsystem offboard;
+    private final DoubleProperty manualTimeout;
+    private final DoubleProperty autoTimeout;
+    
+    private TargetCubeInfo chosenTarget;
+    
+    public enum TimeoutPreset {
+        Manual,
+        Auto
+    }
+    
+    @Inject
+    public IdentifyTargetCubeCommand(OffboardInterfaceSubsystem offboard, XPropertyManager propMan) {
+        this.offboard = offboard;
+
+        this.manualTimeout = propMan.createPersistentProperty(getPrefix() + "Manual timeout", 0.2);
+        this.autoTimeout = propMan.createPersistentProperty(getPrefix() + "Auto timeout", 1);
+        
+        setTimeoutPreset(TimeoutPreset.Manual);
+    }
+    
+    public TargetCubeInfo getChosenTarget() {
+        return chosenTarget;
+    }
+    
+    public void setTimeoutPreset(TimeoutPreset timeoutPreset) {
+        this.setTimeout(timeoutPreset == TimeoutPreset.Auto ? autoTimeout.get() : manualTimeout.get());
+    }
+    
+    @Override
+    public void initialize() {
+        chosenTarget = null;
+    }
+
+    @Override
+    public void execute() {
+        if (chosenTarget == null) {
+            chosenTarget = offboard.getTargetCube();
+        }
+    }
+    
+    @Override
+    public boolean isFinished() {
+        return this.isTimedOut() || chosenTarget != null;
+    }
+
+}

--- a/Competition2018/src/main/java/competition/subsystems/offboard/commands/PurePursuitToVisibleCubeCommand.java
+++ b/Competition2018/src/main/java/competition/subsystems/offboard/commands/PurePursuitToVisibleCubeCommand.java
@@ -2,6 +2,7 @@ package competition.subsystems.offboard.commands;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Supplier;
 
 import com.google.inject.Inject;
 
@@ -24,6 +25,8 @@ public class PurePursuitToVisibleCubeCommand extends PurePursuitCommand {
     private final PoseSubsystem poseSubsystem;
     private final ZedDeploySubsystem zedDeploy;
     
+    private Supplier<TargetCubeInfo> targetSupplier;
+    
     @Inject
     public PurePursuitToVisibleCubeCommand(
             CommonLibFactory clf,
@@ -37,7 +40,12 @@ public class PurePursuitToVisibleCubeCommand extends PurePursuitCommand {
         this.offboardSubsystem = offboardSubsystem;
         this.poseSubsystem = poseSubsystem;
         this.zedDeploy = zedDeploy;
+        
         this.requires(zedDeploy);
+    }
+    
+    public void setTargetCubeSupplier(Supplier<TargetCubeInfo> targetSupplier) {
+        this.targetSupplier = targetSupplier;
     }
     
     @Override
@@ -48,7 +56,7 @@ public class PurePursuitToVisibleCubeCommand extends PurePursuitCommand {
     
     @Override
     protected List<FieldPose> getOriginalPoints() {
-        TargetCubeInfo targetCube = offboardSubsystem.getTargetCube();
+        TargetCubeInfo targetCube = targetSupplier == null ? offboardSubsystem.getTargetCube() : targetSupplier.get();
         if (targetCube == null) {
             return null;
         }

--- a/Competition2018/src/main/java/competition/subsystems/offboard/commands/RumbleIfNoTargetAvailableCommand.java
+++ b/Competition2018/src/main/java/competition/subsystems/offboard/commands/RumbleIfNoTargetAvailableCommand.java
@@ -1,0 +1,49 @@
+package competition.subsystems.offboard.commands;
+
+import java.util.function.Supplier;
+
+import com.google.inject.Inject;
+
+import competition.operator_interface.RumbleManager;
+import xbot.common.command.BaseCommand;
+import xbot.common.properties.DoubleProperty;
+import xbot.common.properties.XPropertyManager;
+
+public class RumbleIfNoTargetAvailableCommand extends BaseCommand {
+    
+    private Supplier<Boolean> isAvailableSupplier;
+    private final DoubleProperty rumbleTime;
+    private final DoubleProperty rumbleIntensity;
+    private final RumbleManager rumbleManager;
+    
+    @Inject
+    public RumbleIfNoTargetAvailableCommand(XPropertyManager propMan, RumbleManager rumbleManager) {
+        this.rumbleManager = rumbleManager;
+        rumbleTime = propMan.createPersistentProperty(getPrefix() + "Rumble time", 0.5);
+        rumbleIntensity = propMan.createPersistentProperty(getPrefix() + "Rumble intensity", 1.0);
+    }
+    
+    public void setIsAvailableSupplier(Supplier<Boolean> isAvailableSupplier) {
+        this.isAvailableSupplier = isAvailableSupplier;
+    }
+    
+    @Override
+    public void initialize() {
+        if (isAvailableSupplier != null) {
+            Boolean isAvailable = isAvailableSupplier.get();
+            if (isAvailable != true) {
+                rumbleManager.rumbleDriverGamepad(rumbleIntensity.get(), rumbleTime.get());
+            }
+        }
+    }
+    
+    @Override
+    public void execute() {
+        // Intentionally left blank
+    }
+
+    @Override
+    public boolean isFinished() {
+        return true;
+    }
+}

--- a/Competition2018/src/main/java/competition/subsystems/offboard/commands/StopRumbleCommand.java
+++ b/Competition2018/src/main/java/competition/subsystems/offboard/commands/StopRumbleCommand.java
@@ -1,0 +1,48 @@
+package competition.subsystems.offboard.commands;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Supplier;
+
+import com.google.inject.Inject;
+
+import competition.operator_interface.RumbleManager;
+import competition.subsystems.offboard.OffboardInterfaceSubsystem;
+import competition.subsystems.offboard.data.TargetCubeInfo;
+import competition.subsystems.pose.PoseSubsystem;
+import competition.subsystems.zed_deploy.ZedDeploySubsystem;
+import xbot.common.command.BaseCommand;
+import xbot.common.injection.wpi_factories.CommonLibFactory;
+import xbot.common.math.ContiguousHeading;
+import xbot.common.math.FieldPose;
+import xbot.common.math.XYPair;
+import xbot.common.properties.DoubleProperty;
+import xbot.common.properties.XPropertyManager;
+import xbot.common.subsystems.drive.BaseDriveSubsystem;
+import xbot.common.subsystems.drive.PurePursuitCommand;
+import xbot.common.subsystems.pose.BasePoseSubsystem;
+
+public class StopRumbleCommand extends BaseCommand {
+    private final RumbleManager rumbleManager;
+    
+    @Inject
+    public StopRumbleCommand(RumbleManager rumbleManager) {
+        this.rumbleManager = rumbleManager;
+    }
+    
+    @Override
+    public void initialize() {
+        rumbleManager.stopDriverGamepadRumble();
+    }
+    
+    @Override
+    public void execute() {
+        
+    }
+    
+    @Override
+    public boolean isFinished() {
+        return true;
+    }
+
+}


### PR DESCRIPTION
Based on https://github.com/Team488/TeamXbot2018/pull/141 (diff for just the new changes is at https://github.com/Team488/TeamXbot2018/commit/7b2ca8b01d013cbf8f276ece2d37f6534351e567).

Depends on https://github.com/Team488/SeriouslyCommonLib/pull/157

---

I created a `RumbleManager` because I want to be able to initiate rumble from within a command group; doing this as a blocking command would mean that the requirements of all other commands in the group are held until the rumble ends (in this case, no driving until the rumble ends).