### PR TITLE
Allow for a little upwards power

### DIFF
--- a/Competition2018/src/main/java/competition/subsystems/elevator/ElevatorSubsystem.java
+++ b/Competition2018/src/main/java/competition/subsystems/elevator/ElevatorSubsystem.java
@@ -294,7 +294,7 @@ public class ElevatorSubsystem extends BaseSetpointSubsystem implements Periodic
 
             // If the upper-bound sensor is hit, then we need to prevent the mechanism from rising any further.
             if (sensorHit) {
-                power = MathUtils.constrainDouble(power, -1, 0);
+                power = MathUtils.constrainDouble(power, -1, 0.1);
                 reason = ElevatorPowerRestrictionReason.UpperLimitSwitch;
             }
         }
@@ -309,7 +309,7 @@ public class ElevatorSubsystem extends BaseSetpointSubsystem implements Periodic
             // if we are above the max, only go down.
             double currentHeight = getCurrentHeightInInches();
             if (currentHeight > getMaxHeightInInches()) {
-                power = MathUtils.constrainDouble(power, -1, 0);
+                power = MathUtils.constrainDouble(power, -1, 0.1);
                 reason = ElevatorPowerRestrictionReason.AboveMaxHeight;
             }
             // if we are below the min, can only go up.

--- a/Competition2018/src/test/java/competition/subsystems/elevator/ElevatorSubsystemTest.java
+++ b/Competition2018/src/test/java/competition/subsystems/elevator/ElevatorSubsystemTest.java
@@ -52,7 +52,7 @@ public class ElevatorSubsystemTest extends BaseCompetitionTest {
         ((MockDigitalInput) elevator.upperLimitSwitch).setValue(true);
         elevator.setPower(1);
 
-        checkElevatorPower(0);
+        checkElevatorPower(0.1);
     }
 /* TODO: FIX THIS ONCE WE NO LONGER HAVE BRUTAL HACK
     @Test


### PR DESCRIPTION
To avoid the weird jerky motion, just allow a little bit of upwards power near the upper limit of the elevator