### PR TITLE
Misc auto system clean-up

### DIFF
--- a/Competition2018/src/main/java/competition/operator_interface/OperatorCommandMap.java
+++ b/Competition2018/src/main/java/competition/operator_interface/OperatorCommandMap.java
@@ -85,17 +85,15 @@ public class OperatorCommandMap {
             ChangeAutoDelayCommand subtractAutoDelay, SelectAdvancedAutonomousCommand selectScale,
             SelectAdvancedAutonomousCommand selectSwitch, SelectAdvancedAutonomousCommand crossLine,
             SelectAdvancedAutonomousCommand doNothing, SetStartingSideCommand setLeft, SetStartingSideCommand setRight,
-            SetStartingSideCommand setMiddle, MultiCubeNearScaleCommandGroup multiCube, SelectAdvancedAutonomousCommand advancedScale) {
+            SetStartingSideCommand setMiddle, SelectAdvancedAutonomousCommand advancedScale) {
 
         selectScale.setMetaprogram(AutonomousMetaprogram.Scale);
         selectSwitch.setMetaprogram(AutonomousMetaprogram.Switch);
         crossLine.setMetaprogram(AutonomousMetaprogram.CrossLine);
-        doNothing.setMetaprogram(AutonomousMetaprogram.Scale);
+        doNothing.setMetaprogram(AutonomousMetaprogram.DoNothing);
         
         addAutoDelay.setDelayChangeAmount(1);
         subtractAutoDelay.setDelayChangeAmount(-1);
-        
-        multiCube.includeOnSmartDashboard("A MultiCube Auto");
 
         setLeft.setStartingLocation(StartingLocations.Left);
         setRight.setStartingLocation(StartingLocations.Right);

--- a/Competition2018/src/main/java/competition/subsystems/autonomous/AutonomousCommandSupplier.java
+++ b/Competition2018/src/main/java/competition/subsystems/autonomous/AutonomousCommandSupplier.java
@@ -9,6 +9,7 @@ import com.google.inject.Singleton;
 import competition.commandgroups.CrossAutoLineCommandGroup;
 import competition.commandgroups.ScoreOnScaleCommandGroup;
 import competition.commandgroups.ScoreOnSwitchCommandGroup;
+import competition.subsystems.autonomous.commands.DriveNowhereCommand;
 import competition.commandgroups.MultiCubeNearScaleCommandGroup;
 import edu.wpi.first.wpilibj.command.Command;
 import openrio.powerup.MatchData.GameFeature;
@@ -20,6 +21,7 @@ import xbot.common.properties.XPropertyManager;
 public class AutonomousCommandSupplier extends BaseSubsystem {
     
     public enum AutonomousMetaprogram {
+        DoNothing,
         Switch,
         Scale,
         Opportunistic,
@@ -33,6 +35,7 @@ public class AutonomousCommandSupplier extends BaseSubsystem {
     ScoreOnScaleCommandGroup singleCubeAnyScale;
     ScoreOnSwitchCommandGroup singleCubeSwitch;
     CrossAutoLineCommandGroup crossLine;
+    DriveNowhereCommand driveNowhere;
     
     AutonomousMetaprogram metaprogram;
     
@@ -46,6 +49,7 @@ public class AutonomousCommandSupplier extends BaseSubsystem {
             ScoreOnScaleCommandGroup singleCubeAnyScale,
             ScoreOnSwitchCommandGroup singleCubeSwitch,
             CrossAutoLineCommandGroup crossLine,
+            DriveNowhereCommand driveNowhere,
             XPropertyManager propMan) {
         this.pathSupplier = pathSupplier;
         this.gameData = gameData;
@@ -53,6 +57,7 @@ public class AutonomousCommandSupplier extends BaseSubsystem {
         this.singleCubeAnyScale = singleCubeAnyScale;
         this.singleCubeSwitch = singleCubeSwitch;
         this.crossLine = crossLine;
+        this.driveNowhere = driveNowhere;
         
         goalFeatureProp = propMan.createEphemeralProperty(getPrefix() + "Goal Feature", "Not set yet");
         
@@ -60,7 +65,7 @@ public class AutonomousCommandSupplier extends BaseSubsystem {
     }
     
     public void setMetaprogram(AutonomousMetaprogram metaprogram) {
-        log.info("Metaprogram is" + metaprogram.toString());
+        log.info("Metaprogram is " + metaprogram.toString());
         this.metaprogram = metaprogram;
         goalFeatureProp.set(metaprogram.toString());
     }
@@ -78,9 +83,12 @@ public class AutonomousCommandSupplier extends BaseSubsystem {
             // if we have a matching side, try the multi cube auto
             log.info("Choosing: Doing single cube scale");
             return singleCubeAnyScale;
-        default:
+        case CrossLine:
             log.info("Choosing: Crossing auto line");
             return crossLine;
+        default:
+            log.info("Choosing: Do nothing");
+            return driveNowhere;
         }
     }
 }

--- a/Competition2018/src/main/java/competition/subsystems/autonomous/AutonomousCommandSupplier.java
+++ b/Competition2018/src/main/java/competition/subsystems/autonomous/AutonomousCommandSupplier.java
@@ -73,6 +73,7 @@ public class AutonomousCommandSupplier extends BaseSubsystem {
     }
     
     public Command chooseAutoToServeMetaprogram() {
+        log.info("Choosing metaprogram; setting is " + metaprogram);
         switch (metaprogram) {
         case Switch:
             log.info("Choosing: Doing single-cube switch");
@@ -84,6 +85,7 @@ public class AutonomousCommandSupplier extends BaseSubsystem {
         case CrossLine:
             log.info("Choosing: Crossing auto line");
             return crossLine;
+        case DoNothing:
         default:
             log.info("Choosing: Do nothing");
             return driveNowhere;

--- a/Competition2018/src/main/java/competition/subsystems/autonomous/AutonomousCommandSupplier.java
+++ b/Competition2018/src/main/java/competition/subsystems/autonomous/AutonomousCommandSupplier.java
@@ -1,6 +1,5 @@
 package competition.subsystems.autonomous;
 
-import java.sql.Savepoint;
 import java.util.function.Supplier;
 
 import com.google.inject.Inject;
@@ -12,7 +11,6 @@ import competition.commandgroups.ScoreOnSwitchCommandGroup;
 import competition.subsystems.autonomous.commands.DriveNowhereCommand;
 import competition.commandgroups.MultiCubeNearScaleCommandGroup;
 import edu.wpi.first.wpilibj.command.Command;
-import openrio.powerup.MatchData.GameFeature;
 import xbot.common.command.BaseSubsystem;
 import xbot.common.properties.StringProperty;
 import xbot.common.properties.XPropertyManager;

--- a/Competition2018/src/main/java/competition/subsystems/autonomous/AutonomousPathSupplier.java
+++ b/Competition2018/src/main/java/competition/subsystems/autonomous/AutonomousPathSupplier.java
@@ -67,17 +67,6 @@ public class AutonomousPathSupplier extends BaseSubsystem {
     public double getDelay() {
         return autonomousDelay.get();
     }
-    
-    public boolean isMatchingScaleSide() {
-        OwnedSide targetSide = gameData.getOwnedSide(GameFeature.SCALE);
-        log.info("Target Side is: " + targetSide);
-
-        boolean matchLeft = targetSide == OwnedSide.LEFT && startingLocation == StartingLocations.Left;
-        boolean matchRight = targetSide == OwnedSide.RIGHT && startingLocation == StartingLocations.Right;
-        boolean eitherMatch = matchLeft || matchRight;
-        log.info("Do we have a matching side? " + eitherMatch);
-        return eitherMatch;
-    }
 
     private List<TotalRobotPoint> mirrorTotalPointPath(List<TotalRobotPoint> path) {
         return mirrorTotalPointPath(path, false);


### PR DESCRIPTION
This hasn't been tested on-robot. In many places there was logic that looked like `if (matches) ... else ...`, which I wanted to replace with definite conditions. That prevents bugs like we had coming in to Portland and makes the system safer; as-is there isn't a way to run a "no-op" command, and if there isn't any match data available it makes arbitrary default choices which include a scale autonomous.